### PR TITLE
Update justfile to publish use latest deployment for used-in-tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,8 @@ publish_has_no_carbon_txt_example:
 
 # update https://used-in-tests.carbontxt.org/
 publish_has_used_in_tests_carbon_txt_example:
-    # see PR #XXX for why we use the `--branch production` flag
+    # see PR #2 for why we use the `--branch production` flag
+    # https://github.com/thegreenwebfoundation/carbon-txt-setup-examples/pull/2
     npx wrangler pages publish cloudflare-domains/used-in-tests-carbon-txt/ --project-name used-in-tests-carbontxt --branch production
 
 list_cloudflare_pages_projects:


### PR DESCRIPTION
When this project was deployed, the branch name was set to `production`, but our default branch is `main`.

By default, cloudflare links the branch name to the latest deploy that carries the same branch name, so calling this (backslashes added for readability):

```
npx wrangler pages publish \
  cloudflare-domains/used-in-tests-carbon-txt/ \
  --project-name used-in-tests-carbontxt
```

Would push the latest version of code in `cloudflare-domains/used-in-tests-carbon-txt/`, but it wouldn't be available at https://used-in-tests.carbontxt.org, because it was still pushed under the `main` branch


![Screenshot 2024-11-26 at 13 40 04](https://github.com/user-attachments/assets/856fa40e-b656-4ffe-a7b8-4ee88094d632)

### The solution

If we wanted to push updates to `production`, one option would be to make sure we are on a branch called `production` and _then_ call the command above. That would get old having to switch back and forth between branches just for one cloudflare project.

It turns out that we can override the branch name for a deployment if we pass an extra `--branch <BRANCH_NAME>` flag. So, if we make our publish command look like this (backslashes added for readability):

```
npx wrangler pages publish \
  cloudflare-domains/used-in-tests-carbon-txt/ \
  --project-name used-in-tests-carbontxt \
  --branch production
```

Then we _can_ deploy to the `production` branch for cloudflare pages, whilst keeping main as the branch we keep the code for various projects in.

**Why not just change the `used-in-tests-carbontxt` to deploy from the `main` branch like all the other projects**

I didn't see an easy way to do this. I'd welcome suggestions if it's straightforward to do this.
